### PR TITLE
Support of specifying a commit to post the status

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ Optional. [Glob](https://github.com/actions/toolkit/tree/master/packages/glob) e
 
 Optional. Check name to use when creating a check run. The default is `Test Report`.
 
+### `commit`
+
+Optional. The commit sha to update the status. This is useful when you run it with `workflow_run`.
+
 ## Example usage
 
 ```yml

--- a/action.js
+++ b/action.js
@@ -7,6 +7,7 @@ const action = async () => {
     core.info(`Going to parse results form ${reportPaths}`);
     const githubToken = core.getInput('github_token');
     const name = core.getInput('check_name');
+    const commit = core.getInput('commit');
 
     let { count, skipped, annotations } = await parseTestReports(reportPaths);
     const foundResults = count > 0 || skipped > 0;
@@ -19,7 +20,7 @@ const action = async () => {
     const link = pullRequest && pullRequest.html_url || github.context.ref;
     const conclusion = foundResults && annotations.length === 0 ? 'success' : 'failure';
     const status = 'completed';
-    const head_sha = pullRequest && pullRequest.head.sha || github.context.sha;
+    const head_sha = commit || pullRequest && pullRequest.head.sha || github.context.sha;
     core.info(
         `Posting status '${status}' with conclusion '${conclusion}' to ${link} (sha: ${head_sha})`
     );

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,9 @@ inputs:
     description: 'check name for test reports'
     required: false
     default: 'Test Report'
+  commit:
+    description: 'commit sha to update the status'
+    required: false
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -29751,6 +29751,7 @@ const action = async () => {
     core.info(`Going to parse results form ${reportPaths}`);
     const githubToken = core.getInput('github_token');
     const name = core.getInput('check_name');
+    const commit = core.getInput('commit');
 
     let { count, skipped, annotations } = await parseTestReports(reportPaths);
     const foundResults = count > 0 || skipped > 0;
@@ -29763,7 +29764,7 @@ const action = async () => {
     const link = pullRequest && pullRequest.html_url || github.context.ref;
     const conclusion = foundResults && annotations.length === 0 ? 'success' : 'failure';
     const status = 'completed';
-    const head_sha = pullRequest && pullRequest.head.sha || github.context.sha;
+    const head_sha = commit || pullRequest && pullRequest.head.sha || github.context.sha;
     core.info(
         `Posting status '${status}' with conclusion '${conclusion}' to ${link} (sha: ${head_sha})`
     );


### PR DESCRIPTION
This PR proposes to add an argument `commit` to specify the target commit to upload the test reports.

**For a bit of background and context:**

Seems currently this plugin cannot be widely used in case of open source projects where the pull requests come from forked repositories. This is a known issue in GitHub Actions because [other secrets are not passed](https://docs.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets#using-encrypted-secrets-in-a-workflow) and [`GITHUB_TOKEN` secret only has read access](https://docs.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token#permissions-for-the-github_token). [Creating the status requires a write access](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-status-checks).

I discussed with GitHub team, and managed to make this plugin working via leveraging  [`workflow_run`](https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/), which. is new feature (10 days ago). However, I had to [fork this repository](https://github.com/HyukjinKwon/action-surefire-report) to make it working with the current fix.

Please see https://github.com/apache/spark/pull/29333 for more details, and https://github.com/HyukjinKwon/spark/runs/979894025 as a demo.

**TL;DR:**

Adding this argument can make this plugin works in most of open source projects where the PRs are from forked repository via having two separate workflows as below:

```yml
name: Build and test

on:
  pull_request:
    branches:
    - master

jobs:
  test:
    runs-on: ubuntu-latest
    - name: Run tests
      # Run tests ...
    - name: Upload test results to report
      if: always()
      uses: actions/upload-artifact@v2
      with:
        name: test-results.xml
        path: "*.xml"
```

```yml
name: Report test results
on:
  workflow_run:
    workflows: ["Build and test"]
    types:
      - completed

jobs:
  test_report:
    runs-on: ubuntu-latest
    steps:
    - name: Download test results to report
      # Download the artifact. See also https://developer.github.com/v3/actions/workflow-runs/
      # and see https://developer.github.com/v3/actions/artifacts/
      # ... workflow: ${{ github.event.workflow_run.workflow_id }} ...
    - name: Publish test report
      with:
        github_token: ${{ secrets.GITHUB_TOKEN }}
        report_paths: "*.xml"
        # Update the test status in the commit that triggered the previous workflow.
        commit: ${{ github.event.workflow_run.head_commit.id }}
```