### PR TITLE
Add capture_stdouterr option

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ Optional. Check will fail if there are test failures. The default is `false`.
 
 Optional. Check will fail if no tests were found. The default is `true`.
 
+### `capture_stdouterr`
+
+Optional. Capture stdout and stderr from each testsuite. The default is `false`.
+
 ## Example usage
 
 ```yml

--- a/action.test.fixtures.js
+++ b/action.test.fixtures.js
@@ -101,8 +101,8 @@ const finishedWithFailures = {
             },
             {
                 path: 'tests/utils/src/test/java/action/surefire/report/calc/CalcUtilsTest.kt',
-                start_line: 27,
-                end_line: 27,
+                start_line: 29,
+                end_line: 29,
                 start_column: 0,
                 end_column: 0,
                 annotation_level: 'failure',
@@ -110,7 +110,7 @@ const finishedWithFailures = {
                 message:
                     'unexpected exception type thrown; expected:<java.lang.IllegalStateException> but was:<java.lang.IllegalArgumentException>',
                 raw_details:
-                    'java.lang.AssertionError: unexpected exception type thrown; expected:<java.lang.IllegalStateException> but was:<java.lang.IllegalArgumentException>\n\tat action.surefire.report.calc.CalcUtilsTest.test error handling(CalcUtilsTest.kt:27)\nCaused by: java.lang.IllegalArgumentException: Amount must have max 2 non-zero decimal places\n\tat action.surefire.report.calc.CalcUtilsTest.scale(CalcUtilsTest.kt:31)\n\tat action.surefire.report.calc.CalcUtilsTest.access$scale(CalcUtilsTest.kt:9)\n\tat action.surefire.report.calc.CalcUtilsTest.test error handling(CalcUtilsTest.kt:27)'
+                    'java.lang.AssertionError: unexpected exception type thrown; expected:<java.lang.IllegalStateException> but was:<java.lang.IllegalArgumentException>\n\tat action.surefire.report.calc.CalcUtilsTest.test error handling(CalcUtilsTest.kt:29)\nCaused by: java.lang.IllegalArgumentException: Amount must have max 2 non-zero decimal places\n\tat action.surefire.report.calc.CalcUtilsTest.scale(CalcUtilsTest.kt:33)\n\tat action.surefire.report.calc.CalcUtilsTest.access$scale(CalcUtilsTest.kt:9)\n\tat action.surefire.report.calc.CalcUtilsTest.test error handling(CalcUtilsTest.kt:29)'
             },
             {
                 path: 'tests/utils/src/test/java/action/surefire/report/calc/CalcUtilsTest.kt',
@@ -123,6 +123,17 @@ const finishedWithFailures = {
                 message: 'Expected: <100.10>\n     but: was <100.11>',
                 raw_details:
                     'java.lang.AssertionError: \n\nExpected: <100.10>\n     but: was <100.11>\n\tat action.surefire.report.calc.CalcUtilsTest.test scale(CalcUtilsTest.kt:15)'
+            },
+            {
+                "annotation_level": "notice",
+                "end_column": 0,
+                "end_line": 0,
+                "message": "stdout and stderr are concatenated below...",
+                "path": "tests/utils/src/test/java/action/surefire/report/calc/CalcUtilsTest.kt",
+                "raw_details": "stdout/stderr:\n===system.out?!\n===system.err?!\n",
+                "start_column": 0,
+                "start_line": 0,
+                "title": "testsuite action.surefire.report.calc.CalcUtilsTest stdout and stderr",
             },
             {
                 path: 'tests/utils/src/test/java/action/surefire/report/calc/StringUtilsTest.java',

--- a/action.test.js
+++ b/action.test.js
@@ -67,6 +67,7 @@ describe('action should work', () => {
     });
 
     it('should parse surefire reports and send a check run to GitHub', async () => {
+        inputs.capture_stdouterr = 'true';
         let request = null;
         const scope = nock('https://api.github.com')
             .post('/repos/scacap/action-surefire-report/check-runs', body => {

--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,10 @@ inputs:
     description: 'fail run if there were no test results found'
     required: false
     default: 'true'
+  capture_stdouterr:
+    description: 'capture stdout and stderr for each testsuite'
+    required: false
+    default: 'false'
 outputs:
   outcome:
      description: 'the test outcome, either `success` or `failure`'

--- a/tests/utils/src/test/java/action/surefire/report/calc/CalcUtilsTest.kt
+++ b/tests/utils/src/test/java/action/surefire/report/calc/CalcUtilsTest.kt
@@ -24,6 +24,8 @@ class CalcUtilsTest {
 
     @Test
     fun `test error handling`() {
+        System.out.println("===system.out?!");
+        System.err.println("===system.err?!");
         assertThrows(IllegalStateException::class.java) { scale("100.001") }
     }
 

--- a/utils.js
+++ b/utils.js
@@ -17,10 +17,12 @@ const resolveFileAndLine = (file, classname, output) => {
 
 const appendStdOutStdErrAnnotations = async (file, testsuite, pathFailuresSet, annotations) => {
     // gradle saves stdout/stderr directly to the XML file
-    const stdOutData = ((testsuite["system-out"] && testsuite["system-out"]._cdata) ||
-                       (testsuite["system-out"] && testsuite["system-out"]._text) || '').trim();
-    const stdErrData = ((testsuite["system-err"] && testsuite["system-err"]._cdata) ||
-                        (testsuite["system-err"] && testsuite["system-err"]._text) || '').trim();
+    const stdOutData = ((testsuite["system-out"] &&
+                         (testsuite["system-out"]._cdata || testsuite["system-out"]._text)) || '')
+                         .trim();
+    const stdErrData = ((testsuite["system-err"] &&
+                         (testsuite["system-err"]._cdata || testsuite["system-err"]._text)) || '')
+                         .trim();
     let raw_details;
     if (!stdErrData && !stdErrData) {
         // maven saves stdout/stderr to an independent file, remove "TEST-" from the file name.

--- a/utils.js
+++ b/utils.js
@@ -167,7 +167,7 @@ async function parseFile(file, captureStdOutErr) {
                     annotation_level: 'failure',
                     title,
                     message,
-                    raw_details: stackTrace,
+                    raw_details: stackTrace
                 });
             }
         }

--- a/utils.js
+++ b/utils.js
@@ -15,6 +15,67 @@ const resolveFileAndLine = (file, classname, output) => {
     return { filename, line: parseInt(line) };
 };
 
+const appendStdOutStdErrAnnotations = async (file, testsuite, pathFailuresSet, annotations) => {
+    // gradle saves stdout/stderr directly to the XML file
+    const stdOutData = ((testsuite["system-out"] && testsuite["system-out"]._cdata) ||
+                       (testsuite["system-out"] && testsuite["system-out"]._text) || '').trim();
+    const stdErrData = ((testsuite["system-err"] && testsuite["system-err"]._cdata) ||
+                        (testsuite["system-err"] && testsuite["system-err"]._text) || '').trim();
+    let raw_details;
+    if (!stdErrData && !stdErrData) {
+        // maven saves stdout/stderr to an independent file, remove "TEST-" from the file name.
+        // http://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#redirectTestOutputToFile
+        let fileExtIndex = file.lastIndexOf(".");
+        if (fileExtIndex < 0) {
+            fileExtIndex = file.length;
+        }
+        // windows path has been canonicalized to '/' path separators by resolvePath. -1 is OK
+        // because we add 1 to look for testFilePrefix.
+        const lastSeparatorIndex = file.lastIndexOf("/");
+        const testFilePrefix = "TEST-";
+        let stdOutFile;
+        if (file.substr(lastSeparatorIndex + 1, testFilePrefix.length) == testFilePrefix) {
+            stdOutFile = file.substr(0, lastSeparatorIndex + 1) +
+                file.substring(lastSeparatorIndex + testFilePrefix.length + 1, fileExtIndex);
+        } else {
+            stdOutFile = file.substring(0, fileExtIndex);
+        }
+        stdOutFile += "-output.txt";
+
+        let stdOutErrData;
+        try {
+            stdOutErrData = await fs.promises.readFile(stdOutFile);
+            core.debug(`Found stdout/stderr in ${stdOutFile}`);
+        } catch (err) {
+            stdOutErrData = null;
+        }
+        raw_details = stdOutErrData ? ("stdout/stderr:\n" + stdOutErrData) : null;
+    } else {
+        core.debug(`Found stdout/stderr in ${file}`);
+        raw_details = ("stdout:\n" + stdOutData + "\n\n\n" + "stderr:\n" + stdErrData);
+    }
+
+    if (raw_details) {
+        // stdout/stderr is captured at the testsuite or test file level, but the metadata within
+        // the xml report may supply a different file path for each failure (as parsed by
+        // parseFile). In this case we can't differentiate which stdout/stderr belongs to which
+        // failed path, so we use the same stdout/stderr for each.
+        for (let pathFailure of pathFailuresSet) {
+           annotations.push({
+                path: pathFailure,
+                start_line: 0,
+                end_line: 0,
+                start_column: 0,
+                end_column: 0,
+                annotation_level: 'notice',
+                title: "testsuite " + testsuite._attributes.name + " stdout and stderr",
+                message: "stdout and stderr are concatenated below...",
+                raw_details,
+            });
+        }
+    }
+}
+
 const resolvePath = async filename => {
     core.debug(`Resolving path for ${filename}`);
     const globber = await glob.create(`**/${filename}.*`, { followSymbolicLinks: false });
@@ -40,10 +101,11 @@ const resolvePath = async filename => {
     return canonicalPath;
 };
 
-async function parseFile(file) {
+async function parseFile(file, captureStdOutErr) {
     core.debug(`Parsing file ${file}`);
     let count = 0;
     let skipped = 0;
+    let failed = 0;
     let annotations = [];
 
     const data = await fs.promises.readFile(file);
@@ -61,10 +123,12 @@ async function parseFile(file) {
             : testsuite.testcase
                 ? [testsuite.testcase]
                 : [];
+        const pathFailuresSet = new Set()
         for (const testcase of testcases) {
             count++;
             if (testcase.skipped) skipped++;
             if (testcase.failure || testcase.error) {
+                failed++;
                 const stackTrace = (
                     (testcase.failure && testcase.failure._cdata) ||
                     (testcase.failure && testcase.failure._text) ||
@@ -92,6 +156,7 @@ async function parseFile(file) {
                 const path = await resolvePath(filename);
                 const title = `${filename}.${testcase._attributes.name}`;
                 core.info(`${path}:${line} | ${message.replace(/\n/g, ' ')}`);
+                pathFailuresSet.add(path);
 
                 annotations.push({
                     path,
@@ -102,27 +167,34 @@ async function parseFile(file) {
                     annotation_level: 'failure',
                     title,
                     message,
-                    raw_details: stackTrace
+                    raw_details: stackTrace,
                 });
             }
         }
+
+        if (captureStdOutErr) {
+            await appendStdOutStdErrAnnotations(file, testsuite, pathFailuresSet, annotations);
+        }
     }
-    return { count, skipped, annotations };
+    return { count, skipped, failed, annotations };
 }
 
-const parseTestReports = async reportPaths => {
+const parseTestReports = async (reportPaths, captureStdOutErr) => {
     const globber = await glob.create(reportPaths, { followSymbolicLinks: false });
     let annotations = [];
     let count = 0;
     let skipped = 0;
+    let failed = 0;
     for await (const file of globber.globGenerator()) {
-        const { count: c, skipped: s, annotations: a } = await parseFile(file);
+        const { count: c, skipped: s, failed: f, annotations: a } =
+                        await parseFile(file, captureStdOutErr);
         if (c == 0) continue;
         count += c;
         skipped += s;
+        failed += f;
         annotations = annotations.concat(a);
     }
-    return { count, skipped, annotations };
+    return { count, skipped, failed, annotations };
 };
 
 module.exports = { resolveFileAndLine, resolvePath, parseFile, parseTestReports };

--- a/utils.test.js
+++ b/utils.test.js
@@ -27,15 +27,15 @@ action.surefire.report.email.InvalidEmailAddressException: Invalid email address
             'action.surefire.report.calc.CalcUtilsTest',
             `
 java.lang.AssertionError: unexpected exception type thrown; expected:<java.lang.IllegalStateException> but was:<java.lang.IllegalArgumentException>
-    at action.surefire.report.calc.CalcUtilsTest.test error handling(CalcUtilsTest.kt:27)
+    at action.surefire.report.calc.CalcUtilsTest.test error handling(CalcUtilsTest.kt:29)
 Caused by: java.lang.IllegalArgumentException: Amount must have max 2 non-zero decimal places
-    at action.surefire.report.calc.CalcUtilsTest.scale(CalcUtilsTest.kt:31)
+    at action.surefire.report.calc.CalcUtilsTest.scale(CalcUtilsTest.kt:33)
     at action.surefire.report.calc.CalcUtilsTest.access$scale(CalcUtilsTest.kt:9)
-    at action.surefire.report.calc.CalcUtilsTest.test error handling(CalcUtilsTest.kt:27)
+    at action.surefire.report.calc.CalcUtilsTest.test error handling(CalcUtilsTest.kt:29)
         `
         );
         expect(filename).toBe('CalcUtilsTest');
-        expect(line).toBe(27);
+        expect(line).toBe(29);
     });
 
     it('should parse correctly filename and line for extended stacktrace', () => {
@@ -96,17 +96,19 @@ describe('resolvePath', () => {
 
 describe('parseFile', () => {
     it('should parse CalcUtils results', async () => {
-        const { count, skipped, annotations } = await parseFile(
-            'tests/utils/target/surefire-reports/TEST-action.surefire.report.calc.CalcUtilsTest.xml'
+        const { count, skipped, failed, annotations } = await parseFile(
+           'tests/utils/target/surefire-reports/TEST-action.surefire.report.calc.CalcUtilsTest.xml',
+           true
         );
 
         expect(count).toBe(2);
         expect(skipped).toBe(0);
+        expect(failed).toBe(2);
         expect(annotations).toStrictEqual([
             {
                 path: 'tests/utils/src/test/java/action/surefire/report/calc/CalcUtilsTest.kt',
-                start_line: 27,
-                end_line: 27,
+                start_line: 29,
+                end_line: 29,
                 start_column: 0,
                 end_column: 0,
                 annotation_level: 'failure',
@@ -114,7 +116,7 @@ describe('parseFile', () => {
                 message:
                     'unexpected exception type thrown; expected:<java.lang.IllegalStateException> but was:<java.lang.IllegalArgumentException>',
                 raw_details:
-                    'java.lang.AssertionError: unexpected exception type thrown; expected:<java.lang.IllegalStateException> but was:<java.lang.IllegalArgumentException>\n\tat action.surefire.report.calc.CalcUtilsTest.test error handling(CalcUtilsTest.kt:27)\nCaused by: java.lang.IllegalArgumentException: Amount must have max 2 non-zero decimal places\n\tat action.surefire.report.calc.CalcUtilsTest.scale(CalcUtilsTest.kt:31)\n\tat action.surefire.report.calc.CalcUtilsTest.access$scale(CalcUtilsTest.kt:9)\n\tat action.surefire.report.calc.CalcUtilsTest.test error handling(CalcUtilsTest.kt:27)'
+                    'java.lang.AssertionError: unexpected exception type thrown; expected:<java.lang.IllegalStateException> but was:<java.lang.IllegalArgumentException>\n\tat action.surefire.report.calc.CalcUtilsTest.test error handling(CalcUtilsTest.kt:29)\nCaused by: java.lang.IllegalArgumentException: Amount must have max 2 non-zero decimal places\n\tat action.surefire.report.calc.CalcUtilsTest.scale(CalcUtilsTest.kt:33)\n\tat action.surefire.report.calc.CalcUtilsTest.access$scale(CalcUtilsTest.kt:9)\n\tat action.surefire.report.calc.CalcUtilsTest.test error handling(CalcUtilsTest.kt:29)'
             },
             {
                 path: 'tests/utils/src/test/java/action/surefire/report/calc/CalcUtilsTest.kt',
@@ -127,14 +129,26 @@ describe('parseFile', () => {
                 message: 'Expected: <100.10>\n     but: was <100.11>',
                 raw_details:
                     'java.lang.AssertionError: \n\nExpected: <100.10>\n     but: was <100.11>\n\tat action.surefire.report.calc.CalcUtilsTest.test scale(CalcUtilsTest.kt:15)'
-            }
+            },
+            {
+                "annotation_level": "notice",
+                "end_column": 0,
+                "end_line": 0,
+                "message": "stdout and stderr are concatenated below...",
+                "path": "tests/utils/src/test/java/action/surefire/report/calc/CalcUtilsTest.kt",
+                "raw_details": "stdout/stderr:\n===system.out?!\n===system.err?!\n",
+                "start_column": 0,
+                "start_line": 0,
+                "title": "testsuite action.surefire.report.calc.CalcUtilsTest stdout and stderr",
+            },
         ]);
     });
     it('should parse pytest results', async () => {
-        const { count, skipped, annotations } = await parseFile('python/report.xml');
+        const { count, skipped, failed, annotations } = await parseFile('python/report.xml', false);
 
         expect(count).toBe(3);
         expect(skipped).toBe(0);
+        expect(failed).toBe(2);
         expect(annotations).toStrictEqual([
             {
                 path: 'python/test_sample.py',


### PR DESCRIPTION
Motivation:
There are scenarios where the stdout and stderr from a testsuite can
provide valuable info to help debug.

Modifications:
- Add a new option `capture_stdouterr` which can capture the stdout and
stderr and publish it as an annotation.

Result:
stdout/stderr is available as annotation for additional context to
debug.