### PR TITLE
don't require manually passing in the github token

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,6 @@ jobs:
       - uses: scacap/action-surefire-report@master
         if: endsWith(github.ref, 'master') == false
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
           check_name: Example Surefire Test Report
       - uses: cclauss/GitHub-Action-for-pytest@0.5.0
         with:
@@ -28,7 +27,6 @@ jobs:
       - uses: scacap/action-surefire-report@master
         if: endsWith(github.ref, 'master') == false
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
           check_name: Example Pytest Report
           report_paths: python/report.xml
       - uses: actions/setup-node@v1

--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ Optional. Check will fail if there are test failures. The default is `false`.
 
 Optional. Check will fail if no tests were found. The default is `true`.
 
+### `github_token`
+
+**Optional**. Usually in form of github_token: ${{ secrets.GITHUB_TOKEN }}. The default is ${{ github.token }}.
+
 ## Example usage
 
 ```yml

--- a/README.md
+++ b/README.md
@@ -9,10 +9,6 @@ This action processes maven surefire or failsafe XML reports on pull requests an
 
 ## Inputs
 
-### `github_token`
-
-**Required**. Usually in form of `github_token: ${{ secrets.GITHUB_TOKEN }}`.
-
 ### `report_paths`
 
 Optional. [Glob](https://github.com/actions/toolkit/tree/master/packages/glob) expression to surefire or failsafe report paths. The default is `**/surefire-reports/TEST-*.xml`.
@@ -52,8 +48,6 @@ jobs:
       - name: Publish Test Report
         if: ${{ always() }}
         uses: scacap/action-surefire-report@v1
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 ## Tips for Gradle

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Optional. Check will fail if no tests were found. The default is `true`.
 
 ### `github_token`
 
-**Optional**. Usually in form of github_token: ${{ secrets.GITHUB_TOKEN }}. The default is ${{ github.token }}.
+Optional. Usually in form of `github_token: ${{ secrets.GITHUB_TOKEN }}`. The default is `${{ github.token }}`.
 
 ## Example usage
 

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,7 @@ inputs:
   github_token:
     description: 'GITHUB_TOKEN'
     required: true
+    default: ${{ github.token }}
   report_paths:
     description: 'surefire/failsafe/junit compatible xml report paths in glob format'
     required: false


### PR DESCRIPTION
Use the GitHub provided `${{ github.token }}` as the default so the user does not need to provide one.

Example of `actions/checkout` using the same [syntax](https://github.com/actions/checkout/blob/main/action.yml#L24).

*This update does **NOT** require existing users to change anything.*