### PR TITLE
Add permissions block in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ jobs:
   build:
     name: Build and Run Tests
     runs-on: ubuntu-latest
+    # Permissions block is optional, useful for dependabot checks
+    permissions:
+      checks: write
+      contents: read
+      issues: read
+      pull-requests: write
     steps:
       - name: Checkout Code
         uses: actions/checkout@v1


### PR DESCRIPTION
Add permissions block in example so that dependabot workflows can work.
See https://github.com/ScaCap/action-surefire-report/issues/31#issuecomment-973980120 for more information.

Related to https://github.com/ScaCap/action-surefire-report/issues/153