### PR TITLE
fix: reset expected values before each test

### DIFF
--- a/action.test.js
+++ b/action.test.js
@@ -12,9 +12,15 @@ const {
 
 jest.setTimeout(20000);
 
-let inputs = {};
-let outputs = {};
-let failed = null;
+let inputs;
+let outputs;
+let failed;
+
+beforeEach(() => {
+    inputs = {};
+    outputs = {};
+    failed = null;
+});
 
 describe('action should work', () => {
     beforeAll(() => {


### PR DESCRIPTION
### What
* Introduced by #81 
* Isolated test passes, but not when run with other tests: https://github.com/ScaCap/action-surefire-report/actions/runs/3782888948/jobs/6431129189

### How
* Reset expected values before each test using `beforeEach` 
