### PR TITLE
 ci: use built in dependency caching and use temurin 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,16 +17,11 @@ jobs:
       checks: write
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-main-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-main-maven-
       - uses: actions/setup-java@v3
         with:
           java-version: 8
-          distribution: 'zulu'
+          distribution: 'temurin'
+          cache: 'maven'
       - run: cd tests && mvn clean test --batch-mode -Dmaven.test.failure.ignore=true
       - uses: ./
         if: github.ref != 'refs/heads/master'
@@ -57,12 +52,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16
-      - uses: actions/cache@v3
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-npm-cache-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-npm-cache-
+          cache: npm
       - run: npm install
       - run: npm run eslint
       - run: npm run test


### PR DESCRIPTION
- Leverage built-in caching features of actions/setup-java. See https://github.com/actions/setup-java#caching-packages-dependencies 
- Leverage built-in caching features of actions/setup-node. See https://github.com/actions/setup-node#caching-packages-dependencies
- Use `temurin` to leverage JDK download cache of base runners. See https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#hosted-tool-cache
