### PR TITLE
Run the action in a container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM node:16-bullseye-slim
+
+COPY dist /dist
+
+ENTRYPOINT ["node", "/dist/index.js"]

--- a/action.yml
+++ b/action.yml
@@ -49,5 +49,5 @@ outputs:
      description: 'the test outcome, either `success` or `failure`'
 
 runs:
-  using: 'node16'
-  main: 'dist/index.js'
+  using: 'docker'
+  image: 'Dockerfile'


### PR DESCRIPTION
### What

Run the action in a container to avoid issues with missing shared libraries, when running on different OSes, or when the whole job runs in a container. Fixes #140 

### How

Build and run a container directly in the job. A better solution would be to build and publish a Docker image to `ghcr.io`, but this should be good enough for now. 