### PR TITLE
Avoid huge input lookup errors

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -16563,7 +16563,7 @@ async function parseFile(file, isFilenameInStackTrace) {
 
     const data = await fs.promises.readFile(file);
 
-    const report = libxmljs.parseXml(data + "");
+    const report = libxmljs.parseXml(data + "", {huge: true});
     const testsuites = report.find('//testsuite');
 
     for (const testsuite of testsuites) {

--- a/utils.js
+++ b/utils.js
@@ -60,7 +60,7 @@ async function parseFile(file, isFilenameInStackTrace) {
 
     const data = await fs.promises.readFile(file);
 
-    const report = libxmljs.parseXml(data + "");
+    const report = libxmljs.parseXml(data + "", {huge: true});
     const testsuites = report.find('//testsuite');
 
     for (const testsuite of testsuites) {


### PR DESCRIPTION
### What

When parsing multiple large XML reports, it sometimes fails with the `Huge input lookup` error coming from the underlying XML parsing library. We have to explicitly allow parsing large files.

```
Run scacap/action-surefire-report@v1.6.0
  with:
    fail_if_no_tests: false
    commit: e191cb9c998956574c4c401f734f9596[2](https://github.com/trinodb/trino/actions/runs/4382083337/jobs/7670771144#step:4:2)120f[4](https://github.com/trinodb/trino/actions/runs/4382083337/jobs/7670771144#step:4:4)92
    github_token: ***
    report_paths: **/surefire-reports/TEST-*.xml, **/failsafe-reports/TEST-*.xml
    create_check: true
    check_name: Test Report
    fail_on_test_failures: false
    skip_publishing: false
    file_name_in_stack_trace: false
Going to parse results form **/surefire-reports/TEST-*.xml
 **/failsafe-reports/TEST-*.xml
Error: internal error: Huge input lookup
```

Fixes https://github.com/ScaCap/action-surefire-report/issues/145

### How

Add the `{huge: true}` option to `libxmljs.parsexml()` call.

Ref: https://github.com/libxmljs/libxmljs/issues/372
