### PR TITLE
fix: mention required permissions in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ jobs:
   build:
     name: Build and Run Tests
     runs-on: ubuntu-latest
+    # Permissions block is optional, useful for dependabot checks
+    permissions:
+      checks: write
+      contents: read
+      issues: read
+      pull-requests: write
     steps:
       - name: Checkout Code
         uses: actions/checkout@v1

--- a/README.md
+++ b/README.md
@@ -52,8 +52,6 @@ jobs:
     permissions:
       checks: write
       contents: read
-      issues: read
-      pull-requests: write
     steps:
       - name: Checkout Code
         uses: actions/checkout@v1


### PR DESCRIPTION
Replacement for https://github.com/ScaCap/action-surefire-report/pull/88

Resolves https://github.com/ScaCap/action-surefire-report/issues/153