### PR TITLE
Revert "Bump @octokit/rest from 19.0.11 to 20.0.2"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@actions/github": "5.1.1",
         "@actions/glob": "0.4.0",
         "@octokit/plugin-retry": "6.0.0",
-        "@octokit/rest": "20.0.2",
+        "@octokit/rest": "19.0.11",
         "xml-js": "1.6.11"
       },
       "devDependencies": {
@@ -1308,6 +1308,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
       "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
+      "peer": true,
       "engines": {
         "node": ">= 18"
       }
@@ -1316,6 +1317,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.0.0.tgz",
       "integrity": "sha512-YbAtMWIrbZ9FCXbLwT9wWB8TyLjq9mxpKdgB3dUNxQcIVTf9hJ70gRPwAcqGZdY6WdJPZ0I7jLaaNDCiloGN2A==",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.0.0",
@@ -1332,12 +1334,14 @@
     "node_modules/@octokit/core/node_modules/@octokit/openapi-types": {
       "version": "18.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-18.0.0.tgz",
-      "integrity": "sha512-V8GImKs3TeQRxRtXFpG2wl19V7444NIOTDF24AWuIbmNaNYOQMWRbjcGDXV5B+0n887fgDcuMNOmlul+k+oJtw=="
+      "integrity": "sha512-V8GImKs3TeQRxRtXFpG2wl19V7444NIOTDF24AWuIbmNaNYOQMWRbjcGDXV5B+0n887fgDcuMNOmlul+k+oJtw==",
+      "peer": true
     },
     "node_modules/@octokit/core/node_modules/@octokit/types": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/@octokit/types/-/types-11.1.0.tgz",
       "integrity": "sha512-Fz0+7GyLm/bHt8fwEqgvRBWwIV1S6wRRyq+V6exRKLVWaKGsuy6H9QFYeBVDV7rK6fO3XwHgQOPxv+cLj2zpXQ==",
+      "peer": true,
       "dependencies": {
         "@octokit/openapi-types": "^18.0.0"
       }
@@ -1346,6 +1350,7 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.0.tgz",
       "integrity": "sha512-szrQhiqJ88gghWY2Htt8MqUDO6++E/EIXqJ2ZEp5ma3uGS46o7LZAzSLt49myB7rT+Hfw5Y6gO3LmOxGzHijAQ==",
+      "peer": true,
       "dependencies": {
         "@octokit/types": "^11.0.0",
         "is-plain-object": "^5.0.0",
@@ -1358,12 +1363,14 @@
     "node_modules/@octokit/endpoint/node_modules/@octokit/openapi-types": {
       "version": "18.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-18.0.0.tgz",
-      "integrity": "sha512-V8GImKs3TeQRxRtXFpG2wl19V7444NIOTDF24AWuIbmNaNYOQMWRbjcGDXV5B+0n887fgDcuMNOmlul+k+oJtw=="
+      "integrity": "sha512-V8GImKs3TeQRxRtXFpG2wl19V7444NIOTDF24AWuIbmNaNYOQMWRbjcGDXV5B+0n887fgDcuMNOmlul+k+oJtw==",
+      "peer": true
     },
     "node_modules/@octokit/endpoint/node_modules/@octokit/types": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/@octokit/types/-/types-11.1.0.tgz",
       "integrity": "sha512-Fz0+7GyLm/bHt8fwEqgvRBWwIV1S6wRRyq+V6exRKLVWaKGsuy6H9QFYeBVDV7rK6fO3XwHgQOPxv+cLj2zpXQ==",
+      "peer": true,
       "dependencies": {
         "@octokit/openapi-types": "^18.0.0"
       }
@@ -1384,6 +1391,7 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.0.1.tgz",
       "integrity": "sha512-T5S3oZ1JOE58gom6MIcrgwZXzTaxRnxBso58xhozxHpOqSTgDS6YNeEUvZ/kRvXgPrRz/KHnZhtb7jUMRi9E6w==",
+      "peer": true,
       "dependencies": {
         "@octokit/request": "^8.0.1",
         "@octokit/types": "^11.0.0",
@@ -1396,20 +1404,22 @@
     "node_modules/@octokit/graphql/node_modules/@octokit/openapi-types": {
       "version": "18.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-18.0.0.tgz",
-      "integrity": "sha512-V8GImKs3TeQRxRtXFpG2wl19V7444NIOTDF24AWuIbmNaNYOQMWRbjcGDXV5B+0n887fgDcuMNOmlul+k+oJtw=="
+      "integrity": "sha512-V8GImKs3TeQRxRtXFpG2wl19V7444NIOTDF24AWuIbmNaNYOQMWRbjcGDXV5B+0n887fgDcuMNOmlul+k+oJtw==",
+      "peer": true
     },
     "node_modules/@octokit/graphql/node_modules/@octokit/types": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/@octokit/types/-/types-11.1.0.tgz",
       "integrity": "sha512-Fz0+7GyLm/bHt8fwEqgvRBWwIV1S6wRRyq+V6exRKLVWaKGsuy6H9QFYeBVDV7rK6fO3XwHgQOPxv+cLj2zpXQ==",
+      "peer": true,
       "dependencies": {
         "@octokit/openapi-types": "^18.0.0"
       }
     },
     "node_modules/@octokit/openapi-types": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-19.0.0.tgz",
-      "integrity": "sha512-PclQ6JGMTE9iUStpzMkwLCISFn/wDeRjkZFIKALpvJQNBGwDoYYi2fFvuHwssoQ1rXI5mfh6jgTgWuddeUzfWw=="
+      "version": "17.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-17.2.0.tgz",
+      "integrity": "sha512-MazrFNx4plbLsGl+LFesMo96eIXkFgEtaKbnNpdh4aQ0VM10aoylFsTYP1AEjkeoRNZiiPe3T6Gl2Hr8dJWdlQ=="
     },
     "node_modules/@octokit/plugin-paginate-rest": {
       "version": "2.21.3",
@@ -1436,14 +1446,11 @@
       }
     },
     "node_modules/@octokit/plugin-request-log": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-4.0.0.tgz",
-      "integrity": "sha512-2uJI1COtYCq8Z4yNSnM231TgH50bRkheQ9+aH8TnZanB6QilOnx8RMD2qsnamSOXtDj0ilxvevf5fGsBhBBzKA==",
-      "engines": {
-        "node": ">= 18"
-      },
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
+      "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
       "peerDependencies": {
-        "@octokit/core": ">=5"
+        "@octokit/core": ">=3"
       }
     },
     "node_modules/@octokit/plugin-rest-endpoint-methods": {
@@ -1504,6 +1511,7 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.1.0.tgz",
       "integrity": "sha512-0gg/NwewU0iXctYBale0VVcCPqOtoW5lsog8cNBJgzV/CyTHa2gicUBOlNnzOk6pJkuwXI34qkq+uRm40PmD4A==",
+      "peer": true,
       "dependencies": {
         "@octokit/endpoint": "^9.0.0",
         "@octokit/request-error": "^5.0.0",
@@ -1544,64 +1552,153 @@
     "node_modules/@octokit/request/node_modules/@octokit/openapi-types": {
       "version": "18.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-18.0.0.tgz",
-      "integrity": "sha512-V8GImKs3TeQRxRtXFpG2wl19V7444NIOTDF24AWuIbmNaNYOQMWRbjcGDXV5B+0n887fgDcuMNOmlul+k+oJtw=="
+      "integrity": "sha512-V8GImKs3TeQRxRtXFpG2wl19V7444NIOTDF24AWuIbmNaNYOQMWRbjcGDXV5B+0n887fgDcuMNOmlul+k+oJtw==",
+      "peer": true
     },
     "node_modules/@octokit/request/node_modules/@octokit/types": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/@octokit/types/-/types-11.1.0.tgz",
       "integrity": "sha512-Fz0+7GyLm/bHt8fwEqgvRBWwIV1S6wRRyq+V6exRKLVWaKGsuy6H9QFYeBVDV7rK6fO3XwHgQOPxv+cLj2zpXQ==",
+      "peer": true,
       "dependencies": {
         "@octokit/openapi-types": "^18.0.0"
       }
     },
     "node_modules/@octokit/rest": {
-      "version": "20.0.2",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-20.0.2.tgz",
-      "integrity": "sha512-Ux8NDgEraQ/DMAU1PlAohyfBBXDwhnX2j33Z1nJNziqAfHi70PuxkFYIcIt8aIAxtRE7KVuKp8lSR8pA0J5iOQ==",
+      "version": "19.0.11",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-19.0.11.tgz",
+      "integrity": "sha512-m2a9VhaP5/tUw8FwfnW2ICXlXpLPIqxtg3XcAiGMLj/Xhw3RSBfZ8le/466ktO1Gcjr8oXudGnHhxV1TXJgFxw==",
       "dependencies": {
-        "@octokit/core": "^5.0.0",
-        "@octokit/plugin-paginate-rest": "^9.0.0",
-        "@octokit/plugin-request-log": "^4.0.0",
-        "@octokit/plugin-rest-endpoint-methods": "^10.0.0"
+        "@octokit/core": "^4.2.1",
+        "@octokit/plugin-paginate-rest": "^6.1.2",
+        "@octokit/plugin-request-log": "^1.0.4",
+        "@octokit/plugin-rest-endpoint-methods": "^7.1.2"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@octokit/rest/node_modules/@octokit/auth-token": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-3.0.4.tgz",
+      "integrity": "sha512-TWFX7cZF2LXoCvdmJWY7XVPi74aSY0+FfBZNSXEXFkMpjcqsQwDSYVv5FhRFaI0V1ECnwbz4j59T/G+rXNWaIQ==",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@octokit/rest/node_modules/@octokit/core": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-4.2.4.tgz",
+      "integrity": "sha512-rYKilwgzQ7/imScn3M9/pFfUf4I1AZEH3KhyJmtPdE2zfaXAn2mFfUy4FbKewzc2We5y/LlKLj36fWJLKC2SIQ==",
+      "dependencies": {
+        "@octokit/auth-token": "^3.0.0",
+        "@octokit/graphql": "^5.0.0",
+        "@octokit/request": "^6.0.0",
+        "@octokit/request-error": "^3.0.0",
+        "@octokit/types": "^9.0.0",
+        "before-after-hook": "^2.2.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@octokit/rest/node_modules/@octokit/endpoint": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.6.tgz",
+      "integrity": "sha512-5L4fseVRUsDFGR00tMWD/Trdeeihn999rTMGRMC1G/Ldi1uWlWJzI98H4Iak5DB/RVvQuyMYKqSK/R6mbSOQyg==",
+      "dependencies": {
+        "@octokit/types": "^9.0.0",
+        "is-plain-object": "^5.0.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@octokit/rest/node_modules/@octokit/graphql": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-5.0.6.tgz",
+      "integrity": "sha512-Fxyxdy/JH0MnIB5h+UQ3yCoh1FG4kWXfFKkpWqjZHw/p+Kc8Y44Hu/kCgNBT6nU1shNumEchmW/sUO1JuQnPcw==",
+      "dependencies": {
+        "@octokit/request": "^6.0.0",
+        "@octokit/types": "^9.0.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/@octokit/rest/node_modules/@octokit/plugin-paginate-rest": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-9.0.0.tgz",
-      "integrity": "sha512-oIJzCpttmBTlEhBmRvb+b9rlnGpmFgDtZ0bB6nq39qIod6A5DP+7RkVLMOixIgRCYSHDTeayWqmiJ2SZ6xgfdw==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-6.1.2.tgz",
+      "integrity": "sha512-qhrmtQeHU/IivxucOV1bbI/xZyC/iOBhclokv7Sut5vnejAIAEXVcGQeRpQlU39E0WwK9lNvJHphHri/DB6lbQ==",
       "dependencies": {
-        "@octokit/types": "^12.0.0"
+        "@octokit/tsconfig": "^1.0.2",
+        "@octokit/types": "^9.2.3"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 14"
       },
       "peerDependencies": {
-        "@octokit/core": ">=5"
+        "@octokit/core": ">=4"
       }
     },
     "node_modules/@octokit/rest/node_modules/@octokit/plugin-rest-endpoint-methods": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-10.0.0.tgz",
-      "integrity": "sha512-16VkwE2v6rXU+/gBsYC62M8lKWOphY5Lg4wpjYnVE9Zbu0J6IwiT5kILoj1YOB53XLmcJR+Nqp8DmifOPY4H3g==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-7.1.2.tgz",
+      "integrity": "sha512-R0oJ7j6f/AdqPLtB9qRXLO+wjI9pctUn8Ka8UGfGaFCcCv3Otx14CshQ89K4E88pmyYZS8p0rNTiprML/81jig==",
       "dependencies": {
-        "@octokit/types": "^12.0.0"
+        "@octokit/types": "^9.2.3",
+        "deprecation": "^2.3.1"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 14"
       },
       "peerDependencies": {
-        "@octokit/core": ">=5"
+        "@octokit/core": ">=3"
       }
     },
-    "node_modules/@octokit/types": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.0.0.tgz",
-      "integrity": "sha512-EzD434aHTFifGudYAygnFlS1Tl6KhbTynEWELQXIbTY8Msvb5nEqTZIm7sbPEt4mQYLZwu3zPKVdeIrw0g7ovg==",
+    "node_modules/@octokit/rest/node_modules/@octokit/request": {
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-6.2.8.tgz",
+      "integrity": "sha512-ow4+pkVQ+6XVVsekSYBzJC0VTVvh/FCTUUgTsboGq+DTeWdyIFV8WSCdo0RIxk6wSkBTHqIK1mYuY7nOBXOchw==",
       "dependencies": {
-        "@octokit/openapi-types": "^19.0.0"
+        "@octokit/endpoint": "^7.0.0",
+        "@octokit/request-error": "^3.0.0",
+        "@octokit/types": "^9.0.0",
+        "is-plain-object": "^5.0.0",
+        "node-fetch": "^2.6.7",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@octokit/rest/node_modules/@octokit/request-error": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-3.0.3.tgz",
+      "integrity": "sha512-crqw3V5Iy2uOU5Np+8M/YexTlT8zxCfI+qu+LxUB7SZpje4Qmx3mub5DfEKSO8Ylyk0aogi6TYdf6kxzh2BguQ==",
+      "dependencies": {
+        "@octokit/types": "^9.0.0",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@octokit/tsconfig": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/tsconfig/-/tsconfig-1.0.2.tgz",
+      "integrity": "sha512-I0vDR0rdtP8p2lGMzvsJzbhdOWy405HcGovrspJ8RRibHnyRgggUSNO5AIox5LmqiwmatHKYsvj6VGFHkqS7lA=="
+    },
+    "node_modules/@octokit/types": {
+      "version": "9.2.3",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.2.3.tgz",
+      "integrity": "sha512-MMeLdHyFIALioycq+LFcA71v0S2xpQUX2cw6pPbHQjaibcHYwLnmK/kMZaWuGfGfjBJZ3wRUq+dOaWsvrPJVvA==",
+      "dependencies": {
+        "@octokit/openapi-types": "^17.2.0"
       }
     },
     "node_modules/@sinclair/typebox": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@actions/core": "1.10.0",
     "@actions/github": "5.1.1",
     "@actions/glob": "0.4.0",
-    "@octokit/rest": "20.0.2",
+    "@octokit/rest": "19.0.11",
     "@octokit/plugin-retry": "6.0.0",
     "xml-js": "1.6.11"
   },


### PR DESCRIPTION
Reverts ScaCap/action-surefire-report#179

### Why
* `@octokit/rest@20` requires Node 18+
* nock is not compatible with Node 18: https://github.com/nock/nock/issues/2336