### PR TITLE
Upgrade to Node 24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
           file_name_in_stack_trace: true
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
       - uses: ScaCap/infra.gh-actions/ci/js/install-safe-chain@v1
       - run: npm install

--- a/action.yml
+++ b/action.yml
@@ -53,5 +53,5 @@ outputs:
      description: 'the test outcome, either `success` or `failure`'
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     "Junit",
     "Surefire"
   ],
+  "engines": {
+    "node": ">=24.0.0"
+  },
   "bugs": {
     "url": "https://github.com/ScaCap/action-surefire-report/issues"
   },


### PR DESCRIPTION
Upgrades the action from Node 20 to Node 24 runtime.

This enables support for NODE_USE_ENV_PROXY, allowing proxy environment variables to be used.