### PR TITLE
PE-3691 Use infra prerelease for npm Nexus CI test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,11 +50,16 @@ jobs:
           check_name: Example Go Report
           report_paths: integration-tests/go/report.xml
           file_name_in_stack_trace: true
-      - uses: actions/setup-node@v4
+      - uses: ScaCap/infra.gh-actions/ci/aws/workflow-secrets@pre-release-PE-3446
         with:
-          node-version: 20
-          cache: npm
-      - uses: ScaCap/infra.gh-actions/ci/js/install-safe-chain@v1
-      - run: npm install
+          additional_cicd_secrets: |
+            NEXUS_NPM_PASSWORD, arn:aws:secretsmanager:eu-central-1:397236901535:secret:prod/github-actions/base/NEXUS_DEV_USER_TOKEN_PASS
+      - uses: ScaCap/infra.gh-actions/ci/js/base@pre-release-PE-3446
+        env:
+          NEXUS_NPM_USERNAME: ${{ vars.NEXUS_DEV_USER_TOKEN_NAME }}
+        with:
+          node_version: 20
+          package_manager: npm
+          enable_nexus_npm: true
       - run: npm run eslint
       - run: npm run test


### PR DESCRIPTION
### What
Use the `infra.gh-actions` pre-release in the npm CI path and enable Nexus pull-through only in CI.

### How
- replace the direct npm setup/install steps with `ci/js/base@pre-release-PE-3446`
- load the Nexus CI secret before dependency installation
- enable `enable_nexus_npm: true`
- keep local npm config unchanged
