### PR TITLE
chore: mark ScaCap/action-surefire-report@v1 as deprecated and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@
 > Active development and future releases have moved to [`ScalableCapital/action-surefire-report@v2`](https://github.com/ScalableCapital/action-surefire-report).
 > New adopters should use `v2`, and existing `v1` users should plan their migration before support ends on `2026-08-01`.
 
-## Migrate to v2
-
 The active repository for version 2 is [`ScalableCapital/action-surefire-report`](https://github.com/ScalableCapital/action-surefire-report).
 Check the migration guide and the new features documented there before switching your workflows.
 

--- a/README.md
+++ b/README.md
@@ -2,13 +2,12 @@
 
 ![](https://github.com/scacap/action-surefire-report/workflows/build/badge.svg)
 
-## ⚠️ Deprecation Warning
+## ⚠️ Moved to v2
 
 > [!WARNING]
-> `ScaCap/action-surefire-report@v1` is a legacy release line.
-> New development has moved to [`ScalableCapital/action-surefire-report@v2`](https://github.com/ScalableCapital/action-surefire-report).
-> New adopters should use `v2`, and existing `v1` users should plan their migration.
-> Support for the `v1` line will end after `2026-08-01`.
+> This repository now hosts the legacy `ScaCap/action-surefire-report@v1` line.
+> Active development and future releases have moved to [`ScalableCapital/action-surefire-report@v2`](https://github.com/ScalableCapital/action-surefire-report).
+> New adopters should use `v2`, and existing `v1` users should plan their migration before support ends on `2026-08-01`.
 
 ## Migrate To v2
 

--- a/README.md
+++ b/README.md
@@ -9,9 +9,6 @@
 > Active development and future releases have moved to [`ScalableCapital/action-surefire-report@v2`](https://github.com/ScalableCapital/action-surefire-report).
 > New adopters should use `v2`, and existing `v1` users should plan their migration before support ends on `2026-08-01`.
 
-The active repository for version 2 is [`ScalableCapital/action-surefire-report`](https://github.com/ScalableCapital/action-surefire-report).
-Check the migration guide and the new features documented there before switching your workflows.
-
 Replace:
 
 ```yml
@@ -24,7 +21,7 @@ With:
 uses: ScalableCapital/action-surefire-report@v2
 ```
 
-The active release line, documentation, and ongoing maintenance now live in the `ScalableCapital` repository.
+The active release line, documentation, and ongoing maintenance now live in the [`ScalableCapital` repository]((https://github.com/ScalableCapital/action-surefire-report)).
 This legacy `v1` line will stop receiving support after `2026-08-01`.
 
 ---

--- a/README.md
+++ b/README.md
@@ -2,6 +2,31 @@
 
 ![](https://github.com/scacap/action-surefire-report/workflows/build/badge.svg)
 
+> [!WARNING]
+> `ScaCap/action-surefire-report@v1` is a legacy release line.
+> New development has moved to [`ScalableCapital/action-surefire-report@v2`](https://github.com/ScalableCapital/action-surefire-report).
+> New adopters should use `v2`, and existing `v1` users should plan their migration.
+> Support for the `v1` line will end after `2026-08-01`.
+
+## Migrate To v2
+
+The active repository for version 2 is [`ScalableCapital/action-surefire-report`](https://github.com/ScalableCapital/action-surefire-report).
+Check the migration guide and the new features documented there before switching your workflows.
+
+Replace:
+
+```yml
+uses: ScaCap/action-surefire-report@v1
+```
+
+With:
+
+```yml
+uses: ScalableCapital/action-surefire-report@v2
+```
+
+The active release line, documentation, and ongoing maintenance now live in the `ScalableCapital` repository.
+This legacy `v1` line will stop receiving support after `2026-08-01`.
 
 This action processes maven surefire or failsafe XML reports on pull requests and shows the result as a PR check with summary and annotations.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 > Active development and future releases have moved to [`ScalableCapital/action-surefire-report@v2`](https://github.com/ScalableCapital/action-surefire-report).
 > New adopters should use `v2`, and existing `v1` users should plan their migration before support ends on `2026-08-01`.
 
-## Migrate To v2
+## Migrate to v2
 
 The active repository for version 2 is [`ScalableCapital/action-surefire-report`](https://github.com/ScalableCapital/action-surefire-report).
 Check the migration guide and the new features documented there before switching your workflows.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 ![](https://github.com/scacap/action-surefire-report/workflows/build/badge.svg)
 
+## ⚠️ Deprecation Warning
+
 > [!WARNING]
 > `ScaCap/action-surefire-report@v1` is a legacy release line.
 > New development has moved to [`ScalableCapital/action-surefire-report@v2`](https://github.com/ScalableCapital/action-surefire-report).
@@ -27,6 +29,8 @@ uses: ScalableCapital/action-surefire-report@v2
 
 The active release line, documentation, and ongoing maintenance now live in the `ScalableCapital` repository.
 This legacy `v1` line will stop receiving support after `2026-08-01`.
+
+---
 
 This action processes maven surefire or failsafe XML reports on pull requests and shows the result as a PR check with summary and annotations.
 

--- a/action.js
+++ b/action.js
@@ -9,8 +9,8 @@ const { parseTestReports } = require('./utils.js');
 const action = async () => {
     core.warning(
         'Deprecated: ScaCap/action-surefire-report@v1 is a legacy release line. ' +
-        'Move to ScalableCapital/action-surefire-report@v2 at https://github.com/ScalableCapital/action-surefire-report. ' +
-        'Support ends after 2026-08-01.'
+        'Move to ScalableCapital/action-surefire-report@v2 at https://github.com/ScalableCapital/action-surefire-report - ' +
+        'support ends after 2026-08-01.'
     );
 
     const reportPaths = core.getInput('report_paths').split(',').join('\n');

--- a/action.js
+++ b/action.js
@@ -7,6 +7,12 @@ const { parseTestReports } = require('./utils.js');
 
 
 const action = async () => {
+    core.warning(
+        'Deprecated: ScaCap/action-surefire-report@v1 is a legacy release line. ' +
+        'Move to ScalableCapital/action-surefire-report@v2 at https://github.com/ScalableCapital/action-surefire-report. ' +
+        'Support ends after 2026-08-01.'
+    );
+
     const reportPaths = core.getInput('report_paths').split(',').join('\n');
     core.info(`Going to parse results form ${reportPaths}`);
     const githubToken = core.getInput('github_token');

--- a/action.test.js
+++ b/action.test.js
@@ -90,6 +90,21 @@ describe('action should work', () => {
         expect(failed).toBeNull();
     });
 
+    it('should emit a deprecation warning for the legacy v1 action line', async () => {
+        const scope = nock('https://api.github.com')
+            .post('/repos/scacap/action-surefire-report/check-runs')
+            .reply(200, {});
+
+        await action();
+        scope.done();
+
+        expect(core.warning).toHaveBeenCalledWith(
+            'Deprecated: ScaCap/action-surefire-report@v1 is a legacy release line. ' +
+            'Move to ScalableCapital/action-surefire-report@v2 at https://github.com/ScalableCapital/action-surefire-report. ' +
+            'Support ends after 2026-08-01.'
+        );
+    });
+
     it('should send all ok if no tests were broken', async () => {
         inputs.report_paths = '**/surefire-reports/TEST-*AllOkTest.xml';
         let request = null;

--- a/action.test.js
+++ b/action.test.js
@@ -100,8 +100,8 @@ describe('action should work', () => {
 
         expect(core.warning).toHaveBeenCalledWith(
             'Deprecated: ScaCap/action-surefire-report@v1 is a legacy release line. ' +
-            'Move to ScalableCapital/action-surefire-report@v2 at https://github.com/ScalableCapital/action-surefire-report. ' +
-            'Support ends after 2026-08-01.'
+            'Move to ScalableCapital/action-surefire-report@v2 at https://github.com/ScalableCapital/action-surefire-report - ' +
+            'support ends after 2026-08-01.'
         );
     });
 

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
-name: 'Surefire Report'
-description: 'Report Surefire test results as annotations on Github Pull Request [junit, failsafe]'
+name: '[DEPRECATED] Surefire Report'
+description: '[DEPRECATED] Legacy v1 line. Move to ScalableCapital/action-surefire-report@v2. Support ends after 2026-08-01.'
 branding:
   icon: 'check-square'
   color: 'green'

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
-name: '[DEPRECATED] Surefire Report'
-description: '[DEPRECATED] Legacy v1 line. Move to ScalableCapital/action-surefire-report@v2. Support ends after 2026-08-01.'
+name: 'Surefire Report (Legacy v1)'
+description: 'Legacy v1 line. Active development moved to ScalableCapital/action-surefire-report@v2. Support ends after 2026-08-01.'
 branding:
   icon: 'check-square'
   color: 'green'

--- a/dist/index.js
+++ b/dist/index.js
@@ -13,6 +13,12 @@ const { parseTestReports } = __nccwpck_require__(4561);
 
 
 const action = async () => {
+    core.warning(
+        'Deprecated: ScaCap/action-surefire-report@v1 is a legacy release line. ' +
+        'Move to ScalableCapital/action-surefire-report@v2 at https://github.com/ScalableCapital/action-surefire-report. ' +
+        'Support ends after 2026-08-01.'
+    );
+
     const reportPaths = core.getInput('report_paths').split(',').join('\n');
     core.info(`Going to parse results form ${reportPaths}`);
     const githubToken = core.getInput('github_token');

--- a/dist/index.js
+++ b/dist/index.js
@@ -15,8 +15,8 @@ const { parseTestReports } = __nccwpck_require__(4561);
 const action = async () => {
     core.warning(
         'Deprecated: ScaCap/action-surefire-report@v1 is a legacy release line. ' +
-        'Move to ScalableCapital/action-surefire-report@v2 at https://github.com/ScalableCapital/action-surefire-report. ' +
-        'Support ends after 2026-08-01.'
+        'Move to ScalableCapital/action-surefire-report@v2 at https://github.com/ScalableCapital/action-surefire-report - ' +
+        'support ends after 2026-08-01.'
     );
 
     const reportPaths = core.getInput('report_paths').split(',').join('\n');


### PR DESCRIPTION
### What
* Mark the action as deprecated
* Announce the move to https://github.com/ScalableCapital/action-surefire-report