### PR TITLE
BOB-1202 - Fully deprecate v1 action

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,11 @@
 
 ![](https://github.com/scacap/action-surefire-report/workflows/build/badge.svg)
 
-## ⚠️ Moved to v2
+## ⚠️ Fully deprecated
 
 > [!WARNING]
-> This repository now hosts the legacy `ScaCap/action-surefire-report@v1` line.
-> Active development and future releases have moved to [`ScalableCapital/action-surefire-report@v2`](https://github.com/ScalableCapital/action-surefire-report).
-> New adopters should use `v2`, and existing `v1` users should plan their migration before support ends on `2026-08-01`.
+> `ScaCap/action-surefire-report@v1` is fully deprecated and is no longer supported. It will receive no further updates or fixes.
+> Use [`ScalableCapital/action-surefire-report@v2`](https://github.com/ScalableCapital/action-surefire-report) instead.
 
 Replace:
 
@@ -21,8 +20,7 @@ With:
 uses: ScalableCapital/action-surefire-report@v2
 ```
 
-The active release line, documentation, and ongoing maintenance now live in the [`ScalableCapital` repository]((https://github.com/ScalableCapital/action-surefire-report)).
-This legacy `v1` line will stop receiving support after `2026-08-01`.
+The active release line, documentation, and ongoing maintenance live in the [`ScalableCapital` repository](https://github.com/ScalableCapital/action-surefire-report).
 
 ---
 

--- a/action.js
+++ b/action.js
@@ -8,9 +8,8 @@ const { parseTestReports } = require('./utils.js');
 
 const action = async () => {
     core.warning(
-        'Deprecated: ScaCap/action-surefire-report@v1 is a legacy release line. ' +
-        'Move to ScalableCapital/action-surefire-report@v2 at https://github.com/ScalableCapital/action-surefire-report - ' +
-        'support ends after 2026-08-01.'
+        'Fully deprecated: ScaCap/action-surefire-report@v1 is no longer supported and will receive no further updates. ' +
+        'Move to ScalableCapital/action-surefire-report@v2: https://github.com/ScalableCapital/action-surefire-report.'
     );
 
     const reportPaths = core.getInput('report_paths').split(',').join('\n');

--- a/action.test.js
+++ b/action.test.js
@@ -90,7 +90,7 @@ describe('action should work', () => {
         expect(failed).toBeNull();
     });
 
-    it('should emit a deprecation warning for the legacy v1 action line', async () => {
+    it('should emit a full deprecation warning for the legacy v1 action line', async () => {
         const scope = nock('https://api.github.com')
             .post('/repos/scacap/action-surefire-report/check-runs')
             .reply(200, {});
@@ -99,9 +99,8 @@ describe('action should work', () => {
         scope.done();
 
         expect(core.warning).toHaveBeenCalledWith(
-            'Deprecated: ScaCap/action-surefire-report@v1 is a legacy release line. ' +
-            'Move to ScalableCapital/action-surefire-report@v2 at https://github.com/ScalableCapital/action-surefire-report - ' +
-            'support ends after 2026-08-01.'
+            'Fully deprecated: ScaCap/action-surefire-report@v1 is no longer supported and will receive no further updates. ' +
+            'Move to ScalableCapital/action-surefire-report@v2: https://github.com/ScalableCapital/action-surefire-report.'
         );
     });
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -14,9 +14,8 @@ const { parseTestReports } = __nccwpck_require__(4561);
 
 const action = async () => {
     core.warning(
-        'Deprecated: ScaCap/action-surefire-report@v1 is a legacy release line. ' +
-        'Move to ScalableCapital/action-surefire-report@v2 at https://github.com/ScalableCapital/action-surefire-report - ' +
-        'support ends after 2026-08-01.'
+        'Fully deprecated: ScaCap/action-surefire-report@v1 is no longer supported and will receive no further updates. ' +
+        'Move to ScalableCapital/action-surefire-report@v2: https://github.com/ScalableCapital/action-surefire-report.'
     );
 
     const reportPaths = core.getInput('report_paths').split(',').join('\n');


### PR DESCRIPTION
## Summary

- mark the legacy v1 action as fully deprecated in the README
- emit a runtime warning that v1 is unsupported and receives no further updates
- rebuild the bundled action and cover the warning with a focused test

## Validation

- `npm run eslint`
- `npx jest action.test.js --runInBand --silent -t "full deprecation" --forceExit`
- `npm run package`

The full Jest suite still has existing fixture-path failures in `utils.test.js`.